### PR TITLE
issue/7 Fix: Force 2 decimal numbers because iATS requires it #7

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -156,3 +156,46 @@ function give_iats_cc_form_callback( $form_id ) {
 }
 
 add_action( 'give_iats_cc_form', 'give_iats_cc_form_callback' );
+
+/**
+ * Override number of decimals settings.
+ *
+ * @since 1.0.2
+ *
+ * @param integer $number_decimals Number of decimals.
+ *
+ * @return int
+ */
+function give_iats_scripts_vars( $number_decimals ) {
+
+	if ( give_is_gateway_active( 'iats' ) ) {
+		$number_decimals = 2;
+	}
+
+	return apply_filters( 'give_iats_number_decimals', $number_decimals );
+}
+
+add_filter( 'give_sanitize_amount_decimals', 'give_iats_scripts_vars', 20, 1 );
+
+
+/**
+ * Override number of decimals from the Form HTML tags.
+ *
+ * @since 1.0.2
+ *
+ * @param array  $form_html_tags
+ * @param object $form
+ *
+ * @return mixed
+ */
+function give_form_add_iats_settings( $form_html_tags, $form ) {
+
+	// Set Number of decimal 2 forcefully if iATS gateway enabled.
+	if ( give_is_gateway_active( 'iats' ) ) {
+		$form_html_tags['data-number_decimals'] = 2;
+	}
+
+	return apply_filters( 'give_iats_form_html_tags', $form_html_tags );
+}
+
+add_filter( 'give_form_html_tags', 'give_form_add_iats_settings', 0, 2 );


### PR DESCRIPTION
@DevinWalker and @mathetos,

This PR will fix #7 

- I have enforce 2 decimal when iATS gateway active.

@DevinWalker Please let me know do we want to readonly Number of decimals in Give core and add tooltip as @mathetos suggested?

Thanks,