### PR TITLE
 fix(iats): getting fatal error when activating the add-on #12

### DIFF
--- a/give-iats.php
+++ b/give-iats.php
@@ -84,27 +84,27 @@ final class Give_iATS_Gateway {
 
 		if ( is_admin() ) {
 			// Add actions.
-			require_once 'includes/admin/give-iats-activation.php';
-			require_once 'includes/admin/give-iats-actions.php';
+			require_once GIVE_IATS_PLUGIN_DIR . '/includes/admin/give-iats-activation.php';
+			require_once GIVE_IATS_PLUGIN_DIR . '/includes/admin/give-iats-actions.php';
 		}
 
 		// iATS payment gateways core.
-		require_once 'includes/lib/iATSPayments/iATS.php';
+		require_once GIVE_IATS_PLUGIN_DIR . '/includes/lib/iATSPayments/iATS.php';
 
 		// Credit card validator core.
-		require_once 'includes/lib/php-credit-card-validator/src/CreditCard.php';
+		require_once GIVE_IATS_PLUGIN_DIR . '/includes/lib/php-credit-card-validator/src/CreditCard.php';
 
 		// Load helper functions.
-		require_once 'includes/functions.php';
+		require_once GIVE_IATS_PLUGIN_DIR . '/includes/functions.php';
 
 		// Add error notice if any.
-		require_once 'includes/class-give-iats-notices.php';
+		require_once GIVE_IATS_PLUGIN_DIR . '/includes/class-give-iats-notices.php';
 
 		// Load plugin settings.
-		require_once 'includes/admin/class-give-iats-gateways-settings.php';
+		require_once GIVE_IATS_PLUGIN_DIR . '/includes/admin/class-give-iats-gateways-settings.php';
 
 		// Process payments.
-		require_once 'includes/give-iats-payment-processing.php';
+		require_once GIVE_IATS_PLUGIN_DIR . '/includes/give-iats-payment-processing.php';
 
 		return self::$instance;
 	}


### PR DESCRIPTION
## Description
PR to fix #12  

## How Has This Been Tested?
Test by activating the add-on and then deactivating the add-on

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/45025846-41a9ea80-b05a-11e8-9444-3aa54c9224ea.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.